### PR TITLE
fix: parseDate stop the js Date behavior that maps 2 digit years to 1900 - 1999

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -67,15 +67,28 @@ const parseDate = (cfg) => {
   if (date instanceof Date) return new Date(date)
   if (typeof date === 'string' && !/Z$/i.test(date)) {
     const d = date.match(C.REGEX_PARSE)
+
+    // Copied and modified from 'shye0000/dayjs'.
+    // https://github.com/iamkun/dayjs/pull/1862
     if (d) {
+      let dObj = null
+      const y = d[1]
       const m = d[2] - 1 || 0
       const ms = (d[7] || '0').substring(0, 3)
+      const dParams = [y, m, d[3] || 1, d[4] || 0, d[5] || 0, d[6] || 0, ms]
       if (utc) {
-        return new Date(Date.UTC(d[1], m, d[3]
-          || 1, d[4] || 0, d[5] || 0, d[6] || 0, ms))
+        dObj = new Date(Date.UTC(...dParams))
+      } else {
+        dObj = new Date(...dParams)
       }
-      return new Date(d[1], m, d[3]
-        || 1, d[4] || 0, d[5] || 0, d[6] || 0, ms)
+
+      // by default the js Date maps 2-digit years 0 - 99 to 1900 – 1999
+      // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date#interpretation_of_two-digit_years
+      // and the setFullYear method could set the exact year, ex:
+      // const date = new Date(98, 1) => Sun Feb 01 1998 00:00:00
+      // date.setFullYear(98)         => Sat Feb 01 0098 00:00:00
+      dObj.setFullYear(y)
+      return dObj
     }
   }
 

--- a/test/parse.test.js
+++ b/test/parse.test.js
@@ -212,4 +212,14 @@ describe('REGEX_PARSE', () => {
     expect(dayjs(date).valueOf()).toBe(moment(date).valueOf())
     expect(d).toBe(null)
   })
+
+  // check parse 2-digit years
+  // https://github.com/iamkun/dayjs/pull/1862
+  it('0001-01-01', () => {
+    const date = '0001-01-01'
+    const d = date.match(REGEX_PARSE)
+    expect(dayjs(date).isValid()).toBe(true)
+    expect(dayjs(date).year()).toBe(1)
+    expect(d.join('-')).toBe('0001-01-01-0001-01-01----')
+  })
 })


### PR DESCRIPTION
Support parsing 2digit years based on the following PR.
- https://github.com/iamkun/dayjs/pull/1862