### PR TITLE
Support parse 2-digit years custom parse format plugin

### DIFF
--- a/src/plugin/customParseFormat/index.js
+++ b/src/plugin/customParseFormat/index.js
@@ -196,17 +196,32 @@ const parseFormattedInput = (input, format, utc, dayjs) => {
     const m = minutes || 0
     const s = seconds || 0
     const ms = milliseconds || 0
-    if (zone) {
-      return new Date(Date.UTC(y, M, d, h, m, s, ms + (zone.offset * 60 * 1000)))
-    }
-    if (utc) {
-      return new Date(Date.UTC(y, M, d, h, m, s, ms))
-    }
-    let newDate
-    newDate = new Date(y, M, d, h, m, s, ms)
-    if (week) {
-      newDate = dayjs(newDate).week(week).toDate()
-    }
+    
+    const newDate = (() => {
+      if (zone) {
+        return new Date(
+          Date.UTC(y, M, d, h, m, s, ms + zone.offset * 60 * 1000)
+        )
+      }
+      if (utc) {
+        return new Date(Date.UTC(y, M, d, h, m, s, ms))
+      }
+
+      const date = new Date(y, M, d, h, m, s, ms)
+      if (week) {
+        return dayjs(date)
+          .week(week)
+          .toDate()
+      }
+      return date
+    })()
+
+    // by default the js Date maps 2-digit years 0 - 99 to 1900 – 1999
+    // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date#interpretation_of_two-digit_years
+    // and the setFullYear method could set the exact year, ex:
+    // const date = new Date(98, 1) => Sun Feb 01 1998 00:00:00
+    // date.setFullYear(98)         => Sat Feb 01 0098 00:00:00
+    newDate.setFullYear(y)
     return newDate
   } catch (e) {
     return new Date('') // Invalid Date

--- a/src/plugin/customParseFormat/index.js
+++ b/src/plugin/customParseFormat/index.js
@@ -218,7 +218,7 @@ const parseFormattedInput = (input, format, utc, dayjs) => {
 
     // by default the js Date maps 2-digit years 0 - 99 to 1900 – 1999
     // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date#interpretation_of_two-digit_years
-    // and the setFullYear method could set the exact year, ex:
+    // and the setFullYear method sets the exact year, ex:
     // const date = new Date(98, 1) => Sun Feb 01 1998 00:00:00
     // date.setFullYear(98)         => Sat Feb 01 0098 00:00:00
     newDate.setFullYear(y)

--- a/test/plugin/customParseFormat.test.js
+++ b/test/plugin/customParseFormat.test.js
@@ -24,6 +24,18 @@ afterEach(() => {
 it('does not break the built-in parsing', () => {
   const input = '2018-05-02 01:02:03.004'
   expect(dayjs(input).valueOf()).toBe(moment(input).valueOf())
+
+  // check parse 2-digit years
+  // https://github.com/iamkun/dayjs/pull/1862
+  const input2 = '0001-02-03 04:05:06.007'
+  const withFormat = dayjs(input2, 'YYYY-MM-DD HH:mm:ss.SSS')
+  const withoutFormat = dayjs(input2)
+  expect(withFormat.valueOf()).toBe(
+    moment(input2, 'YYYY-MM-DD HH:mm:ss.SSS').valueOf()
+  )
+  expect(withFormat.year()).toBe(1)
+  expect(withoutFormat.valueOf()).toBe(moment(input2).valueOf())
+  expect(withoutFormat.year()).toBe(1)
 })
 
 it('parse padded string', () => {


### PR DESCRIPTION
CustomFormatPlugin now also correctly converts date strings containing 2-digit years.

Related: 
- https://github.com/basemachina/dayjs/pull/1