### PR TITLE
Fix mock module name to @basemachina/dayjs from dayjs

### DIFF
--- a/test/__mocks__/@basemachina/dayjs.js
+++ b/test/__mocks__/@basemachina/dayjs.js
@@ -1,0 +1,3 @@
+const dayjs = require('../../../src')
+
+module.exports = dayjs

--- a/test/__mocks__/dayjs.js
+++ b/test/__mocks__/dayjs.js
@@ -1,3 +1,0 @@
-const dayjs = require('../../src')
-
-module.exports = dayjs


### PR DESCRIPTION
Fixed an error in module resolution for some tests.
```sh
 test/locale/zh-cn.test.js
  ● Test suite failed to run

    Cannot find module '@basemachina/dayjs' from 'zh-cn.js'

    
      
      at Resolver.resolveModule (node_modules/jest-resolve/build/index.js:169:17)
      at Object.<anonymous> (src/locale/zh-cn.js:484:33)
```


This is due to the following PR fixes.
- https://github.com/basemachina/dayjs/pull/4

